### PR TITLE
Fixes for sscanf_s/localtime_s/fopen_s issues

### DIFF
--- a/parser/mpFuncStr.cpp
+++ b/parser/mpFuncStr.cpp
@@ -39,6 +39,13 @@
 #include "mpValue.h"
 #include "mpError.h"
 
+#ifdef _MSC_VER
+#  define SSCANF sscanf_s
+#  define SWSCANF swscan_s
+#else
+#  define SSCANF sscanf
+#  define SWSCANF swscanf
+#endif
 
 MUP_NAMESPACE_START
 
@@ -158,9 +165,9 @@ MUP_NAMESPACE_START
     in = a_pArg[0]->GetString();
     
 #ifndef MUP_USE_WIDE_STRING    
-    sscanf_s(in.c_str(), "%lf", &out);
+    SSCANF(in.c_str(), "%lf", &out);
 #else
-    swscanf_s(in.c_str(), _T("%lf"), &out);
+    SWSCANF(in.c_str(), _T("%lf"), &out);
 #endif
 
     *ret = (float_type)out;

--- a/sample/example.cpp
+++ b/sample/example.cpp
@@ -225,9 +225,15 @@ public:
 		time_t t = time(nullptr);
 		struct tm newtime;
 
+#ifdef _MSC_VER
 		errno_t err = localtime_s(&newtime, &t);
 		if (err != 0)
 			return;
+#else
+		auto* r = localtime_r(&t, &newtime);
+		if (!r)
+			return;
+#endif
 
 #ifdef _DEBUG
 		strftime(outstr, sizeof(outstr), "Result_%Y%m%d_%H%M%S_dbg.txt", &newtime);
@@ -289,9 +295,15 @@ public:
 		parser.DefineConst(_T("e"), (float_type)M_E);
 
 		FILE* pFile;
+#ifdef _MSC_VER
 		err = fopen_s(&pFile, outstr, "w");
 		if (err != 0)
 			return;
+#else
+		pFile = fopen(outstr, "w");
+		if (!pFile)
+			return;
+#endif
 
 		int iCount = 400000;
 


### PR DESCRIPTION
Workaround for mainly Microsoft Visual Studio C API. Some Linux C runtimes do support this - see https://en.cppreference.com/w/c/io/fscanf and even if supported it says we need to define __STDC_WANT_LIB_EXT1__ before #include <stdio.h> which makes the usage hacky.